### PR TITLE
fix(dashboard): return to home on greenhouse change

### DIFF
--- a/apps/lychee_client/src/app/components/ui/header/header.component.ts
+++ b/apps/lychee_client/src/app/components/ui/header/header.component.ts
@@ -120,5 +120,8 @@ export class HeaderComponent implements OnInit {
   public onGreenhouseChange(greenhouse: Greenhouse) {
     this.gotoPage("home");
     this.greenhouseService.selectedSerre.set(greenhouse);
+    if (this.router.url !== "/home") {
+      this.router.navigate(["/home"]);
+    }
   }
 }


### PR DESCRIPTION
Navigation à la page home au changement de serre pour palier le problème du dashboard qui reload pas au changement.

## Changements

- [x] Fonctionnalité
- [x] Correction de bug
- [ ] Refactor / nettoyage
- [ ] Outillage / CI
- [ ] Autre :

## Vérifications

- [x] Code formaté (`pnpm format`)
- [x] Tests passés (`pnpm test` / `dotnet test`)
- [x] Titre clair et descriptif
